### PR TITLE
Updated the installation code and fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 ```bash
 $ git clone https://github.com/ultrasecurity/Storm-Breaker
 $ cd Storm-Breaker
-$ sudo bash linux-installer.sh
-$ python3 -m pip install -r requirments.txt
+$ sudo bash install.sh
+$ python3 -m pip install -r requirements.txt
 $ sudo python3 Storm-Breaker.py
 ```


### PR DESCRIPTION
The repository no longer maintained linux-installer.sh but refers to it as install.sh. So changed the code on the readme file with the correct code. Additionally, there was a typo in the name of the document "requirements". I have fixed the name of the document to the correct one in another pull request, and have updated the code here in the readme file.