### PR TITLE
install.sh: fix RST color

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,7 @@ elif [ "$KERNEL" = "openbsd"  ]; then
         
 elif [ "$KERNEL" = "darwin" ]; then
     printf "${PUL}Which package manager do you have?\n${RST}"
-    printf "  1) ${GRN}MacPorts${RST}       2) ${GRN}Homebrew\n{RST}"
+    printf "  1) ${GRN}MacPorts${RST}       2) ${GRN}Homebrew\n${RST}"
 
     printf "\n(1 or 2) ${GRY}#${RST} "
     read -r pm


### PR DESCRIPTION
	Which package manager do you have?
	   1) MacPorts       2) Homebrew
->	{RST}
	(1 or 2) #

Signed-off-by: Peppe289 <gsperanza204@gmail.com>