### PR TITLE
Fix Install.sh to use a bsd sed pattern.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -153,17 +153,15 @@ fi
 
 
 if [ "$KERNEL" != "darwin" ]; then
-    pythonV="$(python3 --version | grep -oP '(?<=\.)\d+(?=\.)')"
-    status=1
+    # make sure grep or sed is not gnu. The default installed one is bsd in macOS.
+    pythonV="$(python3 --version | sed 's/[^0-9]* 3\.\([0-9]*\)\.[0-9]*/\1/' )"
     if [ "${pythonV}" -ge 11 ]; then
         env python3 -m pip install -r --break-system-packages ./requirements.txt
-        status=$?
     else
         env python3 -m pip install -r ./requirements.txt
-        status=$?
     fi
 
-    if [ "${status}" -ne 0 ]; then
+    if [ "$?" -ne 0 ]; then
         printf "${RED}An error occurred! seems pip doesn't work.\n${RST}"
         exit 1
     fi


### PR DESCRIPTION
 grep -P is a option of gnu grep.

macOS(darwin)'s default grep(bsd version) doesn't have `-P`(perl) option.

It will solve macOS user issues in [the link](https://github.com/ultrasecurity/Storm-Breaker/issues?q=is%3Aissue+is%3Aopen+requirement).