### PR TITLE
Fix wrong pip option parameter place in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -156,7 +156,7 @@ if [ "$KERNEL" != "darwin" ]; then
     pythonV="$(python3 --version | grep -oP '(?<=\.)\d+(?=\.)')"
     status=1
     if [ "${pythonV}" -ge 11 ]; then
-        env python3 -m pip install -r --break-system-packages ./requirements.txt
+        env python3 -m pip install --break-system-packages -r ./requirements.txt
         status=$?
     else
         env python3 -m pip install -r ./requirements.txt


### PR DESCRIPTION
It was just a syntax error.