### PR TITLE
Updated install.sh regarding requirements.txt error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -174,7 +174,7 @@ elif [ "$KERNEL" != "darwin" ]; then
     pythonV="$(python3 --version | grep -oP '(?<=\.)\d+(?=\.)')"
     status=1
     if [ "${pythonV}" -ge 11 ]; then
-        env python3 -m pip install -r --break-system-packages ./requirements.txt
+        env python3 -m pip install -r ./requirements.txt
         status=$?
     else
         env python3 -m pip install -r ./requirements.txt


### PR DESCRIPTION
I removed the "--break-system-packages" flag from line 177 in install.sh. After some testing and consideration, it seems this flag might be causing unintended interference with system packages during the installation process. By removing it, we aim to ensure a smoother installation experience for users without risking disruptions to their system packages.
The "--break-system-packages" flag is powerful, but it might be a bit too aggressive for our use case. This change is geared towards enhancing compatibility and minimizing potential conflicts, making the installation process more user-friendly.

Check issue #305 for more details about the error.