### PR TITLE
Fixed An Error Caused During bash install.sh command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -127,7 +127,7 @@ else
                 exit 1
             fi
 
-            python3.8 -m pip install -r ./requirements.txt
+            python3.8 -m pip install -r requirements.txt
             if [ "$?" -ne 0 ]; then
                 printf "${RED}An error occurred! seems pip doesn't work.\n${RST}"
                 exit 1
@@ -152,7 +152,7 @@ else
         elif [ "$pm" = "2" ]; then
             brew update
             brew install python php
-            python3 -m pip install -r ./requirements.txt
+            python3 -m pip install -r requirements.txt
             if [ "$?" -ne 0 ]; then
                 printf "${RED}An error occurred! seems brew doesn't work.\n${RST}"
                 exit 1
@@ -174,10 +174,10 @@ elif [ "$KERNEL" != "darwin" ]; then
     pythonV="$(python3 --version | grep -oP '(?<=\.)\d+(?=\.)')"
     status=1
     if [ "${pythonV}" -ge 11 ]; then
-        env python3 -m pip install -r --break-system-packages ./requirements.txt
+        env python3 -m pip install -r requirements.txt --break-system-packages
         status=$?
     else
-        env python3 -m pip install -r ./requirements.txt
+        env python3 -m pip install -r requirements.txt
         status=$?
     fi
 


### PR DESCRIPTION
"" ./ "" in "" ./requirements.txt "" was causing an error, i.e.
ERROR: Invalid requirement: './requirements.txt'
Hint: It looks like a path. The path does exist. The argument you provided (./requirements.txt) appears to be a requirements file. If that is the case, use the '-r' flag to install the packages specified within it. An error occurred! seems pip doesn't work.